### PR TITLE
Fix: implement release order

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,12 +18,14 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.0.0",
         "@payos/node": "^1.0.10",
         "@prisma/client": "^6.7.0",
         "@types/multer": "^1.4.13",
         "bcryptjs": "^3.0.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "cookie-parser": "^1.4.7",
         "handlebars": "^4.7.8",
         "ioredis": "^5.6.1",
         "nodemailer": "^7.0.3",
@@ -43,6 +45,7 @@
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
         "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
@@ -3826,6 +3829,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -5230,6 +5245,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -5364,6 +5388,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw=="
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -7917,12 +7946,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -8005,6 +8052,18 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -11241,6 +11300,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.0.0",
     "@payos/node": "^1.0.10",
     "@prisma/client": "^6.7.0",
     "@types/multer": "^1.4.13",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,8 @@ import { SharedModule } from './common/shared.module';
 import { RedisModule, RedisModuleOptions } from '@nestjs-modules/ioredis';
 import { PaymentModule } from './payment/payment.module';
 import { NotificationModule } from './notification/notification.module';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TicketCleanupService } from './issuedticket/ticket-cleanup.service';
 
 @Module({
   imports: [
@@ -48,8 +50,9 @@ import { NotificationModule } from './notification/notification.module';
     }),
     PaymentModule,
     NotificationModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, TicketCleanupService],
 })
 export class AppModule { }

--- a/backend/src/issuedticket/ticket-cleanup.service.spec.ts
+++ b/backend/src/issuedticket/ticket-cleanup.service.spec.ts
@@ -1,0 +1,47 @@
+import { TicketCleanupService } from './ticket-cleanup.service';
+import { TicketStatus } from '../issuedticket/ticket-status.enum';
+
+describe('TicketCleanupService', () => {
+  let service: TicketCleanupService;
+  let prisma: any;
+
+  beforeEach(() => {
+    prisma = {
+      issuedTicket: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    };
+    service = new TicketCleanupService(prisma);
+    jest.clearAllMocks();
+  });
+
+  it('should release expired held tickets', async () => {
+    const now = new Date();
+    const expired = [
+      { id: 't1', status: TicketStatus.HELD, holdExpiresAt: new Date(now.getTime() - 1000) },
+      { id: 't2', status: TicketStatus.HELD, holdExpiresAt: new Date(now.getTime() - 2000) },
+    ];
+    prisma.issuedTicket.findMany.mockResolvedValue(expired);
+    prisma.issuedTicket.updateMany.mockResolvedValue({ count: 2 });
+
+    await service.releaseExpiredHolds();
+
+    expect(prisma.issuedTicket.findMany).toHaveBeenCalledWith({
+      where: {
+        status: TicketStatus.HELD,
+        holdExpiresAt: { lt: expect.any(Date) },
+      },
+    });
+    expect(prisma.issuedTicket.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ['t1', 't2'] } },
+      data: { status: TicketStatus.AVAILABLE, holdExpiresAt: null },
+    });
+  });
+
+  it('should do nothing if no expired tickets', async () => {
+    prisma.issuedTicket.findMany.mockResolvedValue([]);
+    await service.releaseExpiredHolds();
+    expect(prisma.issuedTicket.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/issuedticket/ticket-cleanup.service.ts
+++ b/backend/src/issuedticket/ticket-cleanup.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+import { TicketStatus } from '../issuedticket/ticket-status.enum';
+
+@Injectable()
+export class TicketCleanupService {
+  private readonly logger = new Logger(TicketCleanupService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async releaseExpiredHolds() {
+    const now = new Date();
+    const expiredTickets = await this.prisma.issuedTicket.findMany({
+      where: {
+        status: TicketStatus.HELD,
+        holdExpiresAt: { lt: now },
+      },
+    });
+    if (expiredTickets.length === 0) return;
+    const ticketIds = expiredTickets.map(t => t.id);
+    await this.prisma.issuedTicket.updateMany({
+      where: { id: { in: ticketIds } },
+      data: { status: TicketStatus.AVAILABLE, holdExpiresAt: null },
+    });
+    this.logger.log(`Released ${ticketIds.length} expired held tickets`);
+  }
+}

--- a/backend/src/order/order-cleanup.service.ts
+++ b/backend/src/order/order-cleanup.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+import { OrderStatus } from './order-status.enum';
+import { PaymentService } from '../payment/payment.service';
+
+@Injectable()
+export class OrderCleanupService {
+  private readonly logger = new Logger(OrderCleanupService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly paymentService: PaymentService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async cancelExpiredOrders() {
+    const now = new Date();
+    // Find all PENDING orders with at least one ticket whose holdExpiresAt is in the past
+    const expiredOrders = await this.prisma.order.findMany({
+      where: {
+        status: OrderStatus.PENDING,
+        tickets: {
+          some: {
+            issuedTicket: {
+              holdExpiresAt: { lt: now },
+            },
+          },
+        },
+      },
+      include: { tickets: { include: { issuedTicket: true } } },
+    });
+    for (const order of expiredOrders) {
+      try {
+        await this.paymentService.cancelPaymentLink(order.id, "Expired order"); // call payment cancel logic
+        this.logger.log(`Cancelled expired order ${order.id}`);
+      } catch (err) {
+        this.logger.error(`Failed to cancel order ${order.id}: ${err.message}`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request enhances the `OrderService` by improving the cancellation process and ensuring proper handling of related ticket items. The changes include adding transactional support, updating ticket statuses, and releasing held tickets when an order is canceled. Additionally, the unit tests have been expanded to verify these new behaviors.

### Enhancements to `OrderService` cancellation logic:
* Introduced a transactional flow using `prisma.$transaction` to ensure atomicity when canceling an order and updating related ticket statuses.
* Added logic to update the status of associated tickets to `AVAILABLE` and release held tickets via `HoldService` when an order is canceled.

### Updates to unit tests:
* Modified the existing test for order cancellation to mock transactional behavior and validate the updated flow.
* Added a new test to ensure that held tickets are released and their statuses are set to `AVAILABLE` upon order cancellation.