### PR TITLE
Fix: Update Issued Tickets from Schema

### DIFF
--- a/backend/src/issuedticket/issuedticket.controller.ts
+++ b/backend/src/issuedticket/issuedticket.controller.ts
@@ -42,4 +42,9 @@ export class IssuedTicketController {
   generateFromSchema(@Body() dto: GenerateIssuedTicketsDto) {
     return this.ticketService.generateTicketsFromSchema(dto);
   }
+
+  @Post('update')
+  updateFromSchema(@Body() dto: GenerateIssuedTicketsDto) {
+    return this.ticketService.updateTicketsFromSchema(dto);
+  }
 }

--- a/backend/src/issuedticket/issuedticket.service.ts
+++ b/backend/src/issuedticket/issuedticket.service.ts
@@ -141,10 +141,11 @@ export class IssuedTicketService {
           }
         } else {
           for (let i = 0; i < ticketClass.quantity; i++) {
+            const seatId = `#${i}`;
             ticketsToCreate.push({
               price: ticketClass.price,
               class: ticketClass.label,
-              seat: '',
+              seat: seatId,
               status: TicketStatus.UNAVAILABLE,
               eventId,
               organizationId,
@@ -207,11 +208,12 @@ export class IssuedTicketService {
         }
       } else {
         for (let i = 0; i < ticketClass.quantity; i++) {
-          const key = `${ticketClass.label}:#${i}`;
+          const seatId = `#${i}`;
+          const key = `${ticketClass.label}:${seatId}`;
           newMap.set(key, {
             price: ticketClass.price,
             class: ticketClass.label,
-            seat: '',
+            seat: seatId,
             status: TicketStatus.UNAVAILABLE,
             eventId,
             organizationId,

--- a/backend/src/issuedticket/issuedticket.service.ts
+++ b/backend/src/issuedticket/issuedticket.service.ts
@@ -175,4 +175,72 @@ export class IssuedTicketService {
       throw new BadRequestException(error.message || 'Failed to update ticket status to AVAILABLE.');
     }
   }
+
+  /**
+   * Update issued tickets for an event to match a new schema.
+   * Preserves tickets that are already sold/claimed.
+   */
+  async updateTicketsFromSchema(dto: GenerateIssuedTicketsDto) {
+    const { eventId, organizationId, currencyId, schema } = dto;
+    const existingTickets = await this.prisma.issuedTicket.findMany({ where: { eventId } });
+    const existingMap = new Map<string, any>();
+    for (const t of existingTickets) {
+      const key = `${t.class}:${t.seat}`;
+      existingMap.set(key, t);
+    }
+
+    // look up
+    const newMap = new Map<string, any>();
+    for (const ticketClass of schema.classes) {
+      if (ticketClass.seats && ticketClass.seats.length > 0) {
+        for (const seat of ticketClass.seats) {
+          const key = `${ticketClass.label}:${seat.seatNumber}`;
+          newMap.set(key, {
+            price: seat.price,
+            class: ticketClass.label,
+            seat: seat.seatNumber,
+            status: TicketStatus.UNAVAILABLE,
+            eventId,
+            organizationId,
+            currencyId,
+          });
+        }
+      } else {
+        for (let i = 0; i < ticketClass.quantity; i++) {
+          const key = `${ticketClass.label}:#${i}`;
+          newMap.set(key, {
+            price: ticketClass.price,
+            class: ticketClass.label,
+            seat: '',
+            status: TicketStatus.UNAVAILABLE,
+            eventId,
+            organizationId,
+            currencyId,
+          });
+        }
+      }
+    }
+
+    for (const [key, newTicket] of newMap.entries()) {
+      if (existingMap.has(key)) {
+        const existing = existingMap.get(key);
+        if (existing.status === TicketStatus.UNAVAILABLE || existing.status === TicketStatus.AVAILABLE) {
+          await this.prisma.issuedTicket.update({
+            where: { id: existing.id },
+            data: { price: newTicket.price, class: newTicket.class, seat: newTicket.seat },
+          });
+        }
+        existingMap.delete(key);
+      } else {
+        await this.prisma.issuedTicket.create({ data: newTicket });
+      }
+    }
+
+    for (const [key, ticket] of existingMap.entries()) {
+      if (ticket.status === TicketStatus.UNAVAILABLE || ticket.status === TicketStatus.AVAILABLE) {
+        await this.prisma.issuedTicket.delete({ where: { id: ticket.id } });
+      }
+    }
+    return { message: 'Tickets updated to match new schema.' };
+  }
 }


### PR DESCRIPTION
This pull request introduces a new feature to update issued tickets based on a schema, improves ticket seat handling, and enhances test coverage for the new functionality. The changes include adding a new `updateTicketsFromSchema` method in the `IssuedTicketService`, updating the controller to expose this functionality via an endpoint, and expanding the test suite to ensure robust validation.

Basically the idea is rendering the 2 schemas as 2 set (set A and set B) then use the idea of set operations to perform the updating logic:

(1) less --> more: union
(2) more --> less: set diff
(3) same --> same, diff seat info, prices --> intersection

For sold/claimed ticket, the update has no effects

### New Feature: Update Tickets from Schema
* [`backend/src/issuedticket/issuedticket.service.ts`](diffhunk://#diff-17bf12c36dad1f87829565bb1286d68ccc2cf8d455a2ce819f0fddccf85775d7R179-R247): Added the `updateTicketsFromSchema` method to synchronize issued tickets with a new schema, preserving sold tickets while updating or deleting unsold ones. This includes handling seat-based and quantity-based ticket updates.
* [`backend/src/issuedticket/issuedticket.controller.ts`](diffhunk://#diff-d8e2d1682d5570cb12c3b6324f8b0e7a36c61cadde3f0a6f61723bf43b1542b0R45-R49): Introduced a new `updateFromSchema` endpoint to expose the `updateTicketsFromSchema` functionality via the API.

### Improvements to Ticket Seat Handling
* [`backend/src/issuedticket/issuedticket.service.ts`](diffhunk://#diff-17bf12c36dad1f87829565bb1286d68ccc2cf8d455a2ce819f0fddccf85775d7R144-R148): Updated ticket generation logic to assign seat identifiers (`#0`, `#1`, etc.) to tickets instead of leaving the seat field empty.

### Expanded Test Coverage
* [`backend/src/issuedticket/issuedticket.service.spec.ts`](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6R369-R712): Added comprehensive tests for the `updateTicketsFromSchema` method, covering various scenarios such as increasing/decreasing ticket quantities, preserving sold tickets, updating prices, and handling seat-based changes (e.g., adding, removing, renaming seats).
* Updated existing test cases to reflect the new seat identifiers for tickets. [[1]](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6L225-R225) [[2]](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6L234-R234) [[3]](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6L243-R243) [[4]](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6L328-R328) [[5]](diffhunk://#diff-c926b34bad773ceab520902bddeeb12ac4e5c58623ac1d641706d42c84567dc6L337-R337)